### PR TITLE
Travis: Use dpkg asio instead of downloading it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ install:
     # This version of catch is known to work.
     - wget --directory-prefix $PREFIX/include
               https://raw.github.com/philsquared/Catch/v1.2.1/single_include/catch.hpp
-    - wget 'https://01.org/sites/default/files/asio-1.10.6.tar.gz'
-    - tar xf asio-1.10.6.tar.gz -C $PREFIX --strip-components=1
 
 before_script:
     - coverage=OFF


### PR DESCRIPTION
ASIO was downloaded and install instead of relying on Debian package.
This leaded to slower build and useless Travis worker bandwidth.

Use the whitelisted libasio-dev apt package.
